### PR TITLE
fixed DESTDIR for beta releases

### DIFF
--- a/template
+++ b/template
@@ -1,6 +1,6 @@
 # Template file for 'zen-browser'
 pkgname=zen-browser
-version=1.0.0a.37
+version=1.7b
 revision=1
 only_for_archs="x86_64"
 wrksrc="${pkgname}-${version}"
@@ -10,8 +10,8 @@ short_desc="Minimalistic web browser"
 maintainer="SalahDin Rezk <salah2112004@gmail.com>"
 license="MPL-2.0"
 homepage="https://www.zen-browser.app/"
-distfiles="https://github.com/zen-browser/desktop/releases/download/${version/a/-a}/zen.linux-specific.tar.bz2"
-checksum=8268311e75dff97b61e576441d4e76e27ee57fd69bd218698f635b87ad5064df
+distfiles="https://github.com/zen-browser/desktop/releases/download/${version/a/-a}/zen.linux-x86_64.tar.bz2"
+checksum=b7276efa47358d8eec2e06a6e4adc324f29c1b10e7e80653fd4724e0f7717fef
 
 do_install() {
 		# Install the files


### PR DESCRIPTION
Since the beta releases started rolling the `zen.linux-specific.tar.bz2` file isn't shipped anymore, so xbps cannot find it. This downloads `zen.linux-x86_64.tar.bz2`, wich seems to work fine.

Also bump to the latest version.

Tested with direct installing and updating first (with the script) and it works, though if a update to beta was attempted before the fix it needs to be removed first (`vpsm un zen-browser`).